### PR TITLE
Remove outdated note from README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,8 +2,6 @@
 
 Middleware that helps to add redux action to the [Rollbar.Telemetry](https://rollbar.com/docs/notifier/rollbar.js/#telemetry)
 
-**Note:** `lib/` is in repo until we publish package on npm
-
 ### Usage
 
 ```


### PR DESCRIPTION
There was a note about the `lib/` directory that no longer applies.